### PR TITLE
Makefile: Fix missing separator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,9 @@ STATIC = $(BIN)/libarchimedes.a
 TEST_DIR = test
 
 TEST_SRC 			= $(shell find $(TEST_DIR) -name "*.test.cpp")
-TEST_DEP 			= $(TEST_SRC:.cpp     =.d)
-TEST_OBJ 			= $(TEST_SRC:.cpp     =.o)
-TEST_TYPES_OBJ 		        = $(TEST_SRC:.cpp     =.types.o)
+TEST_DEP 			= $(TEST_SRC:.cpp=.d)
+TEST_OBJ 			= $(TEST_SRC:.cpp=.o)
+TEST_TYPES_OBJ 		        = $(TEST_SRC:.cpp=.types.o)
 TEST_OUT 			= $(TEST_SRC:.test.cpp=)
 TEST_OUT_NAMES 		        = $(notdir $(TEST_OUT))
 


### PR DESCRIPTION
Invoking make gives the error `test/this.test.cpp:4: *** missing separator.  Stop.` This patch fixes this.
Tested with GNU Make 4.3 built for x86_64-pc-linux-gnu.

Unrelated to this patch, the rest of build gets stuck in a couple places, I may look into this.